### PR TITLE
Fix for stomp parameter lists

### DIFF
--- a/res/php/stomp/stomp.php
+++ b/res/php/stomp/stomp.php
@@ -10,14 +10,10 @@ class Stomp
      * @param string $username
      * @param string $password
      * @param array $headers
-     * @param string $broker
-     * @param string $username
-     * @param string $password
-     * @param array $headers
      *
      * @return resource
      */
-    public function __construct($broker = 'ini_get("stomp.default_broker_uri")', $username = NULL, $password = NULL, $headers = array(), $broker = 'ini_get("stomp.default_broker_uri")', $username = NULL, $password = NULL, $headers = array())
+    public function __construct($broker = 'ini_get("stomp.default_broker_uri")', $username = NULL, $password = NULL, $headers = array())
     {
     }
 
@@ -37,13 +33,10 @@ class Stomp
      *
      * @param string $transaction_id
      * @param array $headers
-     * @param resource $link
-     * @param string $transaction_id
-     * @param array $headers
      *
      * @return bool 
      */
-    public function abort($transaction_id, $headers = array(), $link, $transaction_id, $headers = array())
+    public function abort($transaction_id, $headers = array())
     {
     }
 
@@ -52,13 +45,10 @@ class Stomp
      *
      * @param mixed $msg
      * @param array $headers
-     * @param resource $link
-     * @param mixed $msg
-     * @param array $headers
      *
      * @return bool 
      */
-    public function ack($msg, $headers = array(), $link, $msg, $headers = array())
+    public function ack($msg, $headers = array())
     {
     }
 
@@ -67,13 +57,10 @@ class Stomp
      *
      * @param string $transaction_id
      * @param array $headers
-     * @param resource $link
-     * @param string $transaction_id
-     * @param array $headers
      *
      * @return bool 
      */
-    public function begin($transaction_id, $headers = array(), $link, $transaction_id, $headers = array())
+    public function begin($transaction_id, $headers = array())
     {
     }
 
@@ -82,57 +69,50 @@ class Stomp
      *
      * @param string $transaction_id
      * @param array $headers
-     * @param resource $link
-     * @param string $transaction_id
-     * @param array $headers
      *
      * @return bool 
      */
-    public function commit($transaction_id, $headers = array(), $link, $transaction_id, $headers = array())
+    public function commit($transaction_id, $headers = array())
     {
     }
 
     /**
      * Gets the last stomp error
      *
-     * @param resource $link
      *
      * @return string Returns an error string or false if no error occurred.
      */
-    public function error($link)
+    public function error()
     {
     }
 
     /**
      * Gets read timeout
      *
-     * @param resource $link
      *
      * @return array Returns an array with 2 elements: sec and usec.
      */
-    public function getReadTimeout($link)
+    public function getReadTimeout()
     {
     }
 
     /**
      * Gets the current stomp session ID
      *
-     * @param resource $link
      *
      * @return string string session id on success.
      */
-    public function getSessionId($link)
+    public function getSessionId()
     {
     }
 
     /**
      * Indicates whether or not there is a frame ready to read
      *
-     * @param resource $link
      *
      * @return bool Returns true if a frame is ready to read, or false otherwise.
      */
-    public function hasFrame($link)
+    public function hasFrame()
     {
     }
 
@@ -140,11 +120,10 @@ class Stomp
      * Reads the next frame
      *
      * @param string $class_name
-     * @param resource $link
      *
      * @return array
      */
-    public function readFrame($class_name = 'stompFrame', $link)
+    public function readFrame($class_name = 'stompFrame')
     {
     }
 
@@ -154,14 +133,10 @@ class Stomp
      * @param string $destination
      * @param mixed $msg
      * @param array $headers
-     * @param resource $link
-     * @param string $destination
-     * @param mixed $msg
-     * @param array $headers
      *
      * @return bool 
      */
-    public function send($destination, $msg, $headers = array(), $link, $destination, $msg, $headers = array())
+    public function send($destination, $msg, $headers = array())
     {
     }
 
@@ -170,13 +145,10 @@ class Stomp
      *
      * @param int $seconds
      * @param int $microseconds
-     * @param resource $link
-     * @param int $seconds
-     * @param int $microseconds
      *
      * @return void
      */
-    public function setReadTimeout($seconds, $microseconds = NULL, $link, $seconds, $microseconds = NULL)
+    public function setReadTimeout($seconds, $microseconds = NULL)
     {
     }
 
@@ -185,13 +157,10 @@ class Stomp
      *
      * @param string $destination
      * @param array $headers
-     * @param resource $link
-     * @param string $destination
-     * @param array $headers
      *
      * @return bool 
      */
-    public function subscribe($destination, $headers = array(), $link, $destination, $headers = array())
+    public function subscribe($destination, $headers = array())
     {
     }
 
@@ -200,13 +169,10 @@ class Stomp
      *
      * @param string $destination
      * @param array $headers
-     * @param resource $link
-     * @param string $destination
-     * @param array $headers
      *
      * @return bool 
      */
-    public function unsubscribe($destination, $headers = array(), $link, $destination, $headers = array())
+    public function unsubscribe($destination, $headers = array())
     {
     }
 }

--- a/res/php/stomp/stomp.php
+++ b/res/php/stomp/stomp.php
@@ -121,7 +121,7 @@ class Stomp
      *
      * @param string $class_name
      *
-     * @return array
+     * @return StompFrame
      */
     public function readFrame($class_name = 'stompFrame')
     {

--- a/src/PHPStubs/DocumentationParser.php
+++ b/src/PHPStubs/DocumentationParser.php
@@ -318,6 +318,10 @@ class DocumentationParser
         foreach ($doc->refsect1 as $refsect) {
             if (isset($refsect->methodsynopsis)) {
                 foreach ($doc->refsect1->methodsynopsis as $methodElem) {
+                    if ((string) $doc->refnamediv->refname != (string) $methodElem->methodname) {
+                        continue;
+                    }
+
                     $method->setAttribute('return_type', (string) $methodElem->type);
 
                     foreach ($methodElem->methodparam as $paramElem) {


### PR DESCRIPTION
The code generates the stub with bad parameter list because of the OOP and functional style documentation and duplicates all parameter.
